### PR TITLE
chore: Add GitHub pull request and issue templates.

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.yaml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yaml
@@ -1,0 +1,41 @@
+name: "Bug Report"
+description: "Report software deficiencies"
+labels: ["bug"]
+body:
+  - type: "markdown"
+    attributes:
+      value: |
+        Use this form to report any functional or performance bugs you've found in the software.
+
+        Be sure to check if your [issue](https://github.com/y-scope/log4j2-appenders/issues) has
+        already been reported.
+
+  - type: "textarea"
+    attributes:
+      label: "Bug"
+      description: "Describe what's wrong and if applicable, what you expected instead."
+    validations:
+      required: true
+
+  - type: "input"
+    attributes:
+      label: "log4j2-appenders version"
+      description: "The release version number or development commit hash that has the bug."
+      placeholder: "Version number or commit hash"
+    validations:
+      required: true
+
+  - type: "textarea"
+    attributes:
+      label: "Environment"
+      description: "The environment in which you're running the appenders."
+      placeholder: "Log4j 2 version, OS version, Docker version, etc."
+    validations:
+      required: true
+
+  - type: "textarea"
+    attributes:
+      label: "Reproduction steps"
+      description: "List each step required to reproduce the bug."
+    validations:
+      required: true

--- a/.github/ISSUE_TEMPLATE/config.yaml
+++ b/.github/ISSUE_TEMPLATE/config.yaml
@@ -1,0 +1,1 @@
+blank_issues_enabled: true

--- a/.github/ISSUE_TEMPLATE/feature-request.yaml
+++ b/.github/ISSUE_TEMPLATE/feature-request.yaml
@@ -1,0 +1,21 @@
+name: "Feature/Change Request"
+description: "Request a feature or change"
+labels: ["enhancement"]
+body:
+  - type: "markdown"
+    attributes:
+      value: "Use this form to request a feature/change in the software, or the project as a whole."
+
+  - type: "textarea"
+    attributes:
+      label: "Request"
+      description: "Describe your request and why it's important."
+    validations:
+      required: true
+
+  - type: "textarea"
+    attributes:
+      label: "Possible implementation"
+      description: "Describe any implementations you have in mind."
+    validations:
+      required: false

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,15 @@
+<!--
+Set the PR title to a meaningful commit message that:
+- follows the Conventional Commits specification (https://www.conventionalcommits.org).
+- is in imperative form.
+
+Example:
+fix: Don't add implicit wildcards ('*') at the beginning and the end of a query (fixes #390).
+-->
+
+# Description
+<!-- Describe what this request will change/fix and provide any details necessary for reviewers. -->
+
+
+# Validation performed
+<!-- Describe what tests and validation you performed on the change. -->


### PR DESCRIPTION
# Description

This adds GH templates for pull requests and issues (bug reports and features). This is largely a copy of our GH templates in other repos like https://github.com/y-scope/clp.

Note that this repo is meant to follow [Conventional Commits](https://www.conventionalcommits.org/).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a structured bug report template to improve issue reporting.
	- Added a feature request template for users to suggest enhancements.
	- Implemented a new pull request template to standardize submissions.
  
- **Chores**
	- Enabled the option for users to create blank issues in the repository.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->