### PR TITLE
ci: Add GH workflow to validate that PR titles follow Conventional Commits.

### DIFF
--- a/.github/pr-title-checks.yaml
+++ b/.github/pr-title-checks.yaml
@@ -1,0 +1,30 @@
+name: "pr-title-checks"
+
+on:
+  # NOTE:
+  # - Using `pull_request_target` means that a pull request will use the workflow config that's on
+  #   the main branch, regardless of whether the pull request modifies this workflow.
+  # - If we use `pull_request` instead of `pull_request_target`, the workflow will fail to run on
+  #   pull requests from external users since their workflow runs don't have access to the
+  #   `GITHUB_TOKEN` secret.
+  pull_request_target:
+    branches: ["main"]
+    types: ["edited", "opened", "reopened"]
+
+permissions:
+  # For amannn/action-semantic-pull-request@v5 to be able to read the PR title.
+  pull-requests: "read"
+
+concurrency:
+  group: "${{github.workflow}}-${{github.ref}}"
+
+  # Cancel in-progress jobs for efficiency
+  cancel-in-progress: true
+
+jobs:
+  conventional-commits:
+    runs-on: "ubuntu-latest"
+    steps:
+      - uses: "amannn/action-semantic-pull-request@v5"
+        env:
+          GITHUB_TOKEN: "${{secrets.GITHUB_TOKEN}}"


### PR DESCRIPTION
<!--
Set the PR title to a meaningful commit message that:
- follows the Conventional Commits specification (https://www.conventionalcommits.org).
- is in imperative form.

Example:
fix: Don't add implicit wildcards ('*') at the beginning and the end of a query (fixes #390).
-->

# Description
<!-- Describe what this request will change/fix and provide any details necessary for reviewers. -->

[Convention Commits](https://www.conventionalcommits.org) is a specification for writing commit messages (or in our case, PR titles) that makes it easy to see at a glance what change the commit makes which in turn makes it easier to generate release notes.

This PR adds a workflow to check PR titles match the spec. Specifically, we use the [amannn/action-semantic-pull-request](https://github.com/amannn/action-semantic-pull-request) action which defaults to using the types specified in [commitizen/conventional-commit-types](https://github.com/commitizen/conventional-commit-types/blob/master/index.json).

NOTE :This PR is a copy of https://github.com/y-scope/spider/pull/1 but with additional comments in the workflow file.

# Validation performed
<!-- Describe what tests and validation you performed on the change. -->

This specific PR hasn't been validated but the code was validated in https://github.com/y-scope/spider/pull/1.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a new GitHub Actions workflow for pull request title checks to enhance contribution guidelines.
  
- **Chores**
	- Added configuration for improved handling of pull requests from external contributors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->