### PR TITLE
build: Add boilerplate Maven project.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
 # Build-related directories and files
 .task/
 target/
+
+# IDE-related directories and files
+.idea/

--- a/README.md
+++ b/README.md
@@ -10,6 +10,27 @@ Initialize and update the submodules:
 git submodule update --init --recursive
 ```
 
+## Requirements
+
+* Java 11
+* Maven 3.8 or newer
+
+## Building
+Build and test:
+```shell
+mvn package
+```
+
+Build without testing:
+```shell
+mvn package -DskipTests
+```
+
+## Testing
+```shell
+mvn test
+```
+
 ## Linting
 Before submitting a pull request, ensure you’ve run the linting [commands](#running-the-linters)
 below and either fixed any violations or suppressed the warnings.

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ git submodule update --init --recursive
 
 ## Requirements
 
-* Java 11
+* JDK 11
 * Maven 3.8 or newer
 
 ## Building

--- a/pom.xml
+++ b/pom.xml
@@ -1,0 +1,270 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <groupId>com.yscope.logging</groupId>
+  <artifactId>log4j2-appenders</artifactId>
+  <version>0.1.0-SNAPSHOT</version>
+  <packaging>jar</packaging>
+
+  <name>Log4j 2 Appenders</name>
+  <description>
+    Log4j 2 appenders for several use cases like compression while logging.
+  </description>
+  <url>https://github.com/y-scope/log4j2-appenders</url>
+  <licenses>
+    <license>
+      <name>Apache License 2.0</name>
+      <url>https://apache.org/licenses/LICENSE-2.0</url>
+    </license>
+  </licenses>
+  <developers>
+    <developer>
+      <name>YScope Inc.</name>
+      <email>dev@yscope.com</email>
+      <organization>YScope Inc.</organization>
+      <organizationUrl>https://yscope.com</organizationUrl>
+    </developer>
+  </developers>
+  <scm>
+    <connection>scm:git:git://github.com/y-scope/log4j2-appenders.git</connection>
+    <developerConnection>
+      scm:git:ssh://git@github.com/y-scope/log4j2-appenders.git
+    </developerConnection>
+    <url>https://github.com/y-scope/log4j2-appenders/tree/main</url>
+  </scm>
+
+  <properties>
+    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+  </properties>
+
+  <dependencies>
+    <!-- Dependencies for testing -->
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-engine</artifactId>
+      <version>5.11.3</version>
+      <scope>test</scope>
+    </dependency>
+  </dependencies>
+
+  <build>
+    <pluginManagement>
+      <!-- Lock plugins versions to avoid using Maven defaults -->
+      <plugins>
+        <plugin>
+          <artifactId>maven-clean-plugin</artifactId>
+          <version>3.4.0</version>
+        </plugin>
+        <plugin>
+          <artifactId>maven-compiler-plugin</artifactId>
+          <version>3.13.0</version>
+        </plugin>
+        <plugin>
+          <artifactId>maven-deploy-plugin</artifactId>
+          <version>3.1.3</version>
+        </plugin>
+        <plugin>
+          <artifactId>maven-enforcer-plugin</artifactId>
+          <version>3.5.0</version>
+        </plugin>
+        <plugin>
+          <artifactId>maven-gpg-plugin</artifactId>
+          <version>3.2.7</version>
+        </plugin>
+        <plugin>
+          <artifactId>maven-install-plugin</artifactId>
+          <version>3.1.3</version>
+        </plugin>
+        <plugin>
+          <artifactId>maven-jar-plugin</artifactId>
+          <version>3.4.2</version>
+        </plugin>
+        <plugin>
+          <artifactId>maven-javadoc-plugin</artifactId>
+          <version>3.10.1</version>
+        </plugin>
+        <plugin>
+          <artifactId>maven-project-info-reports-plugin</artifactId>
+          <version>3.8.0</version>
+        </plugin>
+        <plugin>
+          <artifactId>maven-resources-plugin</artifactId>
+          <version>3.3.1</version>
+        </plugin>
+        <plugin>
+          <artifactId>maven-shade-plugin</artifactId>
+          <version>3.6.0</version>
+        </plugin>
+        <plugin>
+          <artifactId>maven-site-plugin</artifactId>
+          <version>4.0.0-M16</version>
+        </plugin>
+        <plugin>
+          <artifactId>maven-source-plugin</artifactId>
+          <version>3.3.1</version>
+        </plugin>
+        <plugin>
+          <artifactId>maven-surefire-plugin</artifactId>
+          <version>3.5.1</version>
+        </plugin>
+        <plugin>
+          <groupId>org.codehaus.mojo</groupId>
+          <artifactId>build-helper-maven-plugin</artifactId>
+          <version>3.6.0</version>
+        </plugin>
+        <plugin>
+          <groupId>org.codehaus.mojo</groupId>
+          <artifactId>exec-maven-plugin</artifactId>
+          <version>3.5.0</version>
+        </plugin>
+        <plugin>
+          <groupId>org.codehaus.mojo</groupId>
+          <artifactId>versions-maven-plugin</artifactId>
+          <version>2.17.1</version>
+        </plugin>
+        <plugin>
+          <groupId>org.sonatype.plugins</groupId>
+          <artifactId>nexus-staging-maven-plugin</artifactId>
+          <version>1.7.0</version>
+        </plugin>
+      </plugins>
+    </pluginManagement>
+    <plugins>
+      <!-- Maven processes plugins
+      a) in the order of the phases in the lifecycle, and
+      b) in order of appearance within each phase.
+      When configuring plugins below, we do our best to order and group by
+      lifecycle phases. -->
+
+      <!-- No phase -->
+      <plugin>
+        <groupId>org.codehaus.mojo</groupId>
+        <artifactId>versions-maven-plugin</artifactId>
+        <configuration>
+          <generateBackupPoms>false</generateBackupPoms>
+        </configuration>
+      </plugin>
+
+      <!-- phase:validate -->
+      <plugin>
+        <artifactId>maven-enforcer-plugin</artifactId>
+        <executions>
+          <execution>
+            <id>enforce-maven</id>
+            <goals>
+              <goal>enforce</goal>
+            </goals>
+            <configuration>
+              <rules>
+                <requireMavenVersion>
+                  <version>3.8</version>
+                </requireMavenVersion>
+              </rules>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+
+      <!-- phase:package -->
+      <plugin>
+        <artifactId>maven-javadoc-plugin</artifactId>
+        <executions>
+          <execution>
+            <id>attach-javadocs</id>
+            <goals>
+              <goal>jar</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
+        <artifactId>maven-source-plugin</artifactId>
+        <executions>
+          <execution>
+            <id>attach-sources</id>
+            <goals>
+              <goal>jar-no-fork</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+
+      <!-- phase:test-compile -->
+      <plugin>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <configuration>
+          <release>11</release>
+        </configuration>
+      </plugin>
+
+      <!-- phase:test -->
+      <plugin>
+        <artifactId>maven-surefire-plugin</artifactId>
+      </plugin>
+    </plugins>
+  </build>
+
+  <profiles>
+    <profile>
+      <id>github_release</id>
+      <distributionManagement>
+        <repository>
+          <id>github</id>
+          <name>GitHub Packages</name>
+          <url>https://maven.pkg.github.com/${env.GITHUB_REPOSITORY}</url>
+        </repository>
+      </distributionManagement>
+    </profile>
+
+    <profile>
+      <id>maven_release</id>
+
+      <distributionManagement>
+        <snapshotRepository>
+          <id>ossrh</id>
+          <url>https://s01.oss.sonatype.org/content/repositories/snapshots</url>
+        </snapshotRepository>
+      </distributionManagement>
+
+      <build>
+        <plugins>
+          <!-- phase:verify -->
+          <plugin>
+            <artifactId>maven-gpg-plugin</artifactId>
+            <executions>
+              <execution>
+                <id>sign-artifacts</id>
+                <phase>verify</phase>
+                <goals>
+                  <goal>sign</goal>
+                </goals>
+              </execution>
+            </executions>
+            <configuration>
+              <!-- Prevent gpg from using pinentry programs -->
+              <gpgArguments>
+                <arg>--pinentry-mode</arg>
+                <arg>loopback</arg>
+              </gpgArguments>
+            </configuration>
+          </plugin>
+
+          <!-- phase:deploy -->
+          <plugin>
+            <groupId>org.sonatype.plugins</groupId>
+            <artifactId>nexus-staging-maven-plugin</artifactId>
+            <extensions>true</extensions>
+            <configuration>
+              <serverId>ossrh</serverId>
+              <nexusUrl>https://s01.oss.sonatype.org/</nexusUrl>
+              <autoReleaseAfterClose>true</autoReleaseAfterClose>
+            </configuration>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+  </profiles>
+</project>

--- a/pom.xml
+++ b/pom.xml
@@ -38,14 +38,28 @@
 
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    <org.apache.logging.log4j.version>2.24.1</org.apache.logging.log4j.version>
+    <org.junit.jupiter.version>5.11.3</org.junit.jupiter.version>
   </properties>
 
   <dependencies>
+    <!-- Provided dependencies -->
+    <dependency>
+      <groupId>org.apache.logging.log4j</groupId>
+      <artifactId>log4j-api</artifactId>
+      <version>${org.apache.logging.log4j.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.logging.log4j</groupId>
+      <artifactId>log4j-core</artifactId>
+      <version>${org.apache.logging.log4j.version}</version>
+    </dependency>
+
     <!-- Dependencies for testing -->
     <dependency>
       <groupId>org.junit.jupiter</groupId>
       <artifactId>junit-jupiter-engine</artifactId>
-      <version>5.11.3</version>
+      <version>${org.junit.jupiter.version}</version>
       <scope>test</scope>
     </dependency>
   </dependencies>
@@ -100,7 +114,7 @@
         </plugin>
         <plugin>
           <artifactId>maven-site-plugin</artifactId>
-          <version>4.0.0-M16</version>
+          <version>3.21.0</version>
         </plugin>
         <plugin>
           <artifactId>maven-source-plugin</artifactId>

--- a/src/main/java/com/yscope/logging/log4j2/Boilerplate.java
+++ b/src/main/java/com/yscope/logging/log4j2/Boilerplate.java
@@ -1,0 +1,13 @@
+package com.yscope.logging.log4j2;
+
+/**
+ * A class to act as a placeholder until we implement an appender.
+ */
+public class Boilerplate {
+    /**
+     * @return A boilerplate greeting.
+     */
+    public static String getGreeting() {
+        return "Hello, world!";
+    }
+}

--- a/src/test/java/com/yscope/logging/log4j2/BoilerplateTests.java
+++ b/src/test/java/com/yscope/logging/log4j2/BoilerplateTests.java
@@ -6,7 +6,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class BoilerplateTests {
     @Test
-    void testGreeting() {
-        assertEquals(Boilerplate.getGreeting(), "Hello, world!");
+    public void testGreeting() {
+        assertEquals("Hello, world!", Boilerplate.getGreeting());
     }
 }

--- a/src/test/java/com/yscope/logging/log4j2/BoilerplateTests.java
+++ b/src/test/java/com/yscope/logging/log4j2/BoilerplateTests.java
@@ -1,0 +1,12 @@
+package com.yscope.logging.log4j2;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class BoilerplateTests {
+    @Test
+    void testGreeting() {
+        assertEquals(Boilerplate.getGreeting(), "Hello, world!");
+    }
+}


### PR DESCRIPTION
<!--
Set the PR title to a meaningful commit message that:
- follows the Conventional Commits specification (https://www.conventionalcommits.org).
- is in imperative form.

Example:
fix: Don't add implicit wildcards ('*') at the beginning and the end of a query (fixes #390).
-->

# Description
<!-- Describe what this request will change/fix and provide any details necessary for reviewers. -->

This adds a boilerplate Maven project that contributors can build on top of. The `pom.xml` file is the amalgamation of best practices from [clp-ffi-java](https://github.com/y-scope/clp-ffi-java/blob/main/pom.xml), [log4j1-appenders](https://github.com/y-scope/log4j1-appenders/blob/main/pom.xml), and new learning.

# Validation performed
<!-- Describe what tests and validation you performed on the change. -->
Validated these commands succeeded:

* `mvn package`
* `mvn package -DskipTests`
* `mvn test`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Added a "Requirements" section in the README for necessary software versions.
	- Expanded "Building" section with detailed build and test instructions.
	- Introduced a "Testing" section with commands for running tests.
	- New project configuration for "Log4j 2 Appenders" with Maven.
	- Added a placeholder class `Boilerplate` with a greeting method.
  
- **Tests**
	- Introduced `BoilerplateTests` to verify the greeting functionality.
  
- **Chores**
	- Updated `.gitignore` to include IDE-related configurations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->