### PR TITLE
ci: Add GitHub workflow to build, test, and release package.

### DIFF
--- a/.github/workflows/build-and-release-package.yaml
+++ b/.github/workflows/build-and-release-package.yaml
@@ -1,0 +1,77 @@
+name: "build-and-release-package"
+
+on:
+  pull_request:
+    paths:
+      - ".github/workflows/build-and-release-package.yaml"
+      - ".gitmodules"
+      - "pom.xml"
+      - "src/**/*"
+  push:
+    paths:
+      - ".github/workflows/build-and-release-package.yaml"
+      - ".gitmodules"
+      - "pom.xml"
+      - "src/**/*"
+  workflow_dispatch:
+
+# Concurrency group to prevent multiple workflow instances from trying to publish releases
+concurrency: "${{github.workflow}}-${{github.ref}}"
+
+permissions: {}
+
+jobs:
+  build-and-release:
+    runs-on: "ubuntu-latest"
+    permissions:
+      # To publish to GitHub packages
+      packages: "write"
+    env:
+      JAVA_DIST: "temurin"
+      JAVA_VERSION: "11"
+    steps:
+      - uses: "actions/checkout@v4"
+        with:
+          submodules: "recursive"
+
+      - uses: "actions/setup-java@v4"
+        with:
+          java-version: "${{env.JAVA_VERSION}}"
+          distribution: "${{env.JAVA_DIST}}"
+          server-id: "github"
+
+      # This will override the setup-java step above
+      - if: "startsWith(github.ref, 'refs/heads/v') && github.event_name == 'workflow_dispatch'"
+        uses: "actions/setup-java@v4"
+        with:
+          java-version: "${{env.JAVA_VERSION}}"
+          distribution: "${{env.JAVA_DIST}}"
+          server-id: "ossrh"
+          server-username: "MAVEN_USERNAME"
+          server-password: "MAVEN_PASSWORD"
+          gpg-private-key: "${{secrets.GPG_PRIVATE_KEY}}"
+          gpg-passphrase: "MAVEN_GPG_PASSPHRASE"
+
+      - name: "Build package, and run tests"
+        run: "mvn --batch-mode package"
+
+      - if: "github.event_name != 'pull_request' && github.ref == 'refs/heads/main'"
+        name: "Deploy to GitHub Packages"
+        run: "mvn --batch-mode deploy -DskipTests -Pgithub_release"
+        env:
+          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+
+      - if: "startsWith(github.ref, 'refs/heads/v') && github.event_name == 'workflow_dispatch'"
+        name: "Deploy to Maven Central"
+        run: "mvn --batch-mode deploy -DskipTests -Pmaven_release"
+        env:
+          MAVEN_USERNAME: "${{secrets.OSSRH_USERNAME}}"
+          MAVEN_PASSWORD: "${{secrets.OSSRH_TOKEN}}"
+          MAVEN_GPG_PASSPHRASE: "${{secrets.GPG_PASSPHRASE}}"
+
+      - uses: "actions/upload-artifact@v4"
+        with:
+          name: "log4j2-appenders"
+          path: "${{github.workspace}}/target/log4j2-appenders-*.jar"
+          if-no-files-found: "error"
+          retention-days: 1


### PR DESCRIPTION
<!--
Set the PR title to a meaningful commit message that:
- follows the Conventional Commits specification (https://www.conventionalcommits.org).
- is in imperative form.

Example:
fix: Don't add implicit wildcards ('*') at the beginning and the end of a query (fixes #390).
-->

# Description
<!-- Describe what this request will change/fix and provide any details necessary for reviewers. -->

Adds GitHub workflows and Maven build profiles to build, test, and release the package to GitHub packages and Maven Central.

The workflows and Maven build profiles are largely based on https://github.com/y-scope/clp-ffi-java/blob/ec7368c112f2caf74519faf50ea472ee967f17ef/.github/workflows/build-and-release-package.yml.

# Validation performed
<!-- Describe what tests and validation you performed on the change. -->

Validated the build workflows succeeds.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a new GitHub Actions workflow for building and releasing packages, enhancing automation for deployments.
  
- **Improvements**
	- Supports manual triggering and includes concurrency settings to prevent simultaneous releases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->