### PR TITLE
ci: migrate from OSSRH to Sonatype Central Portal

### DIFF
--- a/.github/workflows/build-and-release-package.yaml
+++ b/.github/workflows/build-and-release-package.yaml
@@ -46,7 +46,7 @@ jobs:
         with:
           java-version: "${{env.JAVA_VERSION}}"
           distribution: "${{env.JAVA_DIST}}"
-          server-id: "ossrh"
+          server-id: "central"
           server-username: "MAVEN_USERNAME"
           server-password: "MAVEN_PASSWORD"
           gpg-private-key: "${{secrets.GPG_PRIVATE_KEY}}"
@@ -65,8 +65,8 @@ jobs:
         name: "Deploy to Maven Central"
         run: "mvn --batch-mode deploy -DskipTests -Pmaven_release"
         env:
-          MAVEN_USERNAME: "${{secrets.OSSRH_USERNAME}}"
-          MAVEN_PASSWORD: "${{secrets.OSSRH_TOKEN}}"
+          MAVEN_USERNAME: "${{secrets.SONATYPE_USERNAME}}"
+          MAVEN_PASSWORD: "${{secrets.SONATYPE_TOKEN}}"
           MAVEN_GPG_PASSPHRASE: "${{secrets.GPG_PASSPHRASE}}"
 
       - uses: "actions/upload-artifact@v4"

--- a/pom.xml
+++ b/pom.xml
@@ -174,9 +174,9 @@
           <version>2.17.1</version>
         </plugin>
         <plugin>
-          <groupId>org.sonatype.plugins</groupId>
-          <artifactId>nexus-staging-maven-plugin</artifactId>
-          <version>1.7.0</version>
+          <groupId>org.sonatype.central</groupId>
+          <artifactId>central-publishing-maven-plugin</artifactId>
+          <version>0.7.0</version>
         </plugin>
       </plugins>
     </pluginManagement>
@@ -306,8 +306,8 @@
 
       <distributionManagement>
         <snapshotRepository>
-          <id>ossrh</id>
-          <url>https://s01.oss.sonatype.org/content/repositories/snapshots</url>
+          <id>central</id>
+          <url>https://central.sonatype.com/repository/maven-snapshots/</url>
         </snapshotRepository>
       </distributionManagement>
 
@@ -336,13 +336,12 @@
 
           <!-- phase:deploy -->
           <plugin>
-            <groupId>org.sonatype.plugins</groupId>
-            <artifactId>nexus-staging-maven-plugin</artifactId>
+            <groupId>org.sonatype.central</groupId>
+            <artifactId>central-publishing-maven-plugin</artifactId>
             <extensions>true</extensions>
             <configuration>
-              <serverId>ossrh</serverId>
-              <nexusUrl>https://s01.oss.sonatype.org/</nexusUrl>
-              <autoReleaseAfterClose>true</autoReleaseAfterClose>
+              <publishingServerId>central</publishingServerId>
+              <autoPublish>true</autoPublish>
             </configuration>
           </plugin>
         </plugins>


### PR DESCRIPTION
## Summary
OSSRH (`s01.oss.sonatype.org`) was [shut down June 2025](https://central.sonatype.org/news/20250326_ossrh_sunset/). Migrate both snapshot and release publishing to the Sonatype Central Portal (`central.sonatype.com`):

- Replace `nexus-staging-maven-plugin` with `central-publishing-maven-plugin` (v0.7.0)
- Update workflow `server-id` from `ossrh` to `central` and secret names from `OSSRH_USERNAME`/`OSSRH_TOKEN` to `SONATYPE_USERNAME`/`SONATYPE_TOKEN`

## Test plan
- [x] Same changes were validated in [metalog's snapshot publish workflow](https://github.com/y-scope/metalog/actions/runs/22691710386)
- [x] `SONATYPE_USERNAME` and `SONATYPE_TOKEN` repo secrets are already configured and tested in metalog