### PR TITLE
fix(ci): Replace `npm install -g @go-task/cli` with `go-task/setup-task` action to eliminate npm supply-chain risk; Use reusable CI actions from `yscope-dev-utils`; Bump `actions/checkout` to v6.0.2.

### DIFF
--- a/.github/workflows/build-and-release-package.yaml
+++ b/.github/workflows/build-and-release-package.yaml
@@ -30,7 +30,7 @@ jobs:
       JAVA_DIST: "temurin"
       JAVA_VERSION: "11"
     steps:
-      - uses: "actions/checkout@v4"
+      - uses: "actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd"  # v6.0.2
         with:
           submodules: "recursive"
 

--- a/.github/workflows/code-linting-checks.yaml
+++ b/.github/workflows/code-linting-checks.yaml
@@ -32,7 +32,9 @@ jobs:
           python-version: "3.10"
 
       - name: "Install task"
-        run: "npm install -g @go-task/cli"
+        uses: "go-task/setup-task@3be4020d41929789a01026e0e427a4321ce0ad44"  # v2.0.0
+        with:
+          version: "3.48.0"
 
       - if: "matrix.os == 'macos-latest'"
         name: "Install coreutils (for md5sum)"

--- a/.github/workflows/code-linting-checks.yaml
+++ b/.github/workflows/code-linting-checks.yaml
@@ -23,28 +23,14 @@ jobs:
         os: ["macos-latest", "ubuntu-latest"]
     runs-on: "${{matrix.os}}"
     steps:
-      - uses: "actions/checkout@v4"
+      - uses: "actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd"  # v6.0.2
         with:
           submodules: "recursive"
 
-      - uses: "actions/setup-python@v5"
-        with:
-          python-version: "3.10"
+      - uses: "./tools/yscope-dev-utils/exports/github/actions/install-python"
 
-      - name: "Install task"
-        uses: "go-task/setup-task@3be4020d41929789a01026e0e427a4321ce0ad44"  # v2.0.0
-        with:
-          version: "3.48.0"
+      - uses: "./tools/yscope-dev-utils/exports/github/actions/install-go-task"
 
-      - if: "matrix.os == 'macos-latest'"
-        name: "Install coreutils (for md5sum)"
-        run: "brew install coreutils"
-
-      - name: "Log tool versions"
-        run: |-
-          md5sum --version
-          python --version
-          tar --version
-          task --version
+      - uses: "./tools/yscope-dev-utils/exports/github/actions/print-tool-versions"
 
       - run: "task lint:check"


### PR DESCRIPTION
<!-- markdownlint-disable MD012 -->

# Description

All CI workflows install the Task runner via `npm install -g @go-task/cli`. `@go-task/cli` declares
a transitive dependency on `axios: ^1.8.2`, and because global npm installs have no lock file, npm
resolves to whatever the latest semver-compatible version is at install time. During the
[axios supply-chain compromise on 2026-03-31][axios-advisory], this caused CI runners to pull in the
malicious `axios@1.14.1` package, which executed a post-install script that connected to an
attacker-controlled C2 server.

This PR:

1. Replaces the `npm install -g @go-task/cli` invocation with the official
   [`go-task/setup-task`][setup-task] GitHub Action, pinned by commit SHA, which downloads the Task
   binary directly from GitHub Releases without involving npm.
2. Updates the `tools/yscope-dev-utils` submodule to [`38bf51e`][dev-utils-commit], which provides
   reusable GitHub Actions for CI setup (install-python, install-go-task, print-tool-versions).
3. Replaces inline `actions/setup-python`, `go-task/setup-task`, macOS coreutils install, and
   tool-version logging steps in `code-linting-checks.yaml` with their reusable equivalents from
   `yscope-dev-utils`.
4. Pins `actions/checkout` to commit SHA `de0fac2e...` (v6.0.2) in all workflows that use it.

# Checklist

* [x] The PR satisfies the [contribution guidelines][yscope-contrib-guidelines].
* [x] This is a breaking change and that has been indicated in the PR title, OR this isn't a
  breaking change.
* [x] Necessary docs have been updated, OR no docs need to be updated.

# Validation performed

1. Verified that no `npm install -g` commands remain in any workflow file.
2. Confirmed the pinned commit SHA `3be4020d41929789a01026e0e427a4321ce0ad44` corresponds to
   `go-task/setup-task` [v2.0.0][setup-task-v2].
3. Confirmed the pinned `actions/checkout` SHA `de0fac2e4500dabe0009e67214ff5f5447ce83dd` corresponds
   to [v6.0.2][checkout-v6].
4. Confirmed `yscope-dev-utils` submodule at `38bf51e` includes the reusable CI actions
   (`install-python`, `install-go-task`, `print-tool-versions`).

[axios-advisory]: https://github.com/advisories/GHSA-fw8c-xr5c-95f9
[checkout-v6]: https://github.com/actions/checkout/releases/tag/v6.0.2
[dev-utils-commit]: https://github.com/y-scope/yscope-dev-utils/commit/38bf51e
[setup-task]: https://github.com/go-task/setup-task
[setup-task-v2]: https://github.com/go-task/setup-task/releases/tag/v2.0.0
[yscope-contrib-guidelines]: https://docs.yscope.com/dev-guide/contrib-guides-overview.html

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated GitHub Actions workflow dependencies to latest pinned versions.
  * Consolidated repetitive workflow setup steps into reusable components.
  * Updated development utilities dependency to latest version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->